### PR TITLE
feat: show PRQL version in about (in `--help` option)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -550,26 +550,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -580,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1066,6 +1064,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "ethnum"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1358,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,6 +1442,28 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itertools"
@@ -1612,6 +1662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,7 +1772,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1845,7 +1901,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1928,7 +1984,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -2566,6 +2622,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,12 +3004,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -3334,12 +3398,57 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3348,10 +3457,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3360,16 +3481,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ atty = "0.2"
 camino = "1.1.1"
 cfg-if = "1.0.0"
 chrono = "0.4"
-clap = { version = "3.2.3", features = ["derive", "env"] }
+clap = { version = "4.1.4", features = ["derive", "env"] }
 datafusion = { version = "12.0.0", optional = true, features = ["default", "avro"]}
 dotenvy = "0.15.3"
 duckdb = { version = "0.5.1", features = ["bundled", "modern-full"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ atty = "0.2"
 camino = "1.1.1"
 cfg-if = "1.0.0"
 chrono = "0.4"
-clap = { version = "4.1.4", features = ["derive", "env"] }
+clap = { version = "4.1.4", features = ["derive", "env", "string"] }
 datafusion = { version = "12.0.0", optional = true, features = ["default", "avro"]}
 dotenvy = "0.15.3"
 duckdb = { version = "0.5.1", features = ["bundled", "modern-full"], optional = true }

--- a/src/backends/datafusion.rs
+++ b/src/backends/datafusion.rs
@@ -102,7 +102,7 @@ fn write_record_batches_to_json(rbs: &[RecordBatch], dest: &mut dyn Write) -> Re
     {
         // let mut writer = json::ArrayWriter::new(&mut buf);
         let mut writer = json::LineDelimitedWriter::new(dest);
-        writer.write_batches(&rbs)?;
+        writer.write_batches(rbs)?;
         writer.finish()?;
     }
     Ok(())

--- a/src/backends/duckdb.rs
+++ b/src/backends/duckdb.rs
@@ -35,7 +35,7 @@ pub fn query(
             } else if source.ends_with(".parquet") {
                 format!("read_parquet('{source}')")
             } else if database.starts_with("postgres") {
-                let mut parts: Vec<&str> = source.split(".").collect();
+                let mut parts: Vec<&str> = source.split('.').collect();
                 if parts.len() == 1 {
                     parts.insert(0, "public");
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::io::prelude::*;
 use std::{fs, io};
 
 use clap::{Parser, ValueEnum};
-use prql_compiler::compile;
+use prql_compiler::{compile, PRQL_VERSION};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "datafusion")] {
@@ -33,7 +33,8 @@ type SourcesType = Vec<(String, String)>;
 #[clap(
     name = env!("CARGO_PKG_NAME"),
     version = env!("CARGO_PKG_VERSION"),
-    about = env!("CARGO_PKG_DESCRIPTION")
+    about = env!("CARGO_PKG_DESCRIPTION"),
+    long_about = format!("pq: query and transform data with PRQL version {} (https://prql-lang.org)", PRQL_VERSION.to_string())
 )]
 struct Cli {
     /// The file(s) to read data FROM if given

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,14 +57,14 @@ struct Cli {
     no_exec: bool,
 
     /// The format to use for the output
-    #[clap(long, arg_enum, value_parser, env = "PQ_FORMAT")]
+    #[clap(long, value_enum, value_parser, env = "PQ_FORMAT")]
     format: Option<OutputFormat>,
 
     /// The Writer to use for writing the output
     #[clap(
         short,
         long,
-        arg_enum,
+        value_enum,
         value_parser,
         default_value = "arrow",
         env = "PQ_WRITER"
@@ -206,12 +206,7 @@ fn main() -> Result<()> {
     if let Some(args_database) = args.database {
         database = args_database;
         if backend == Backend::auto {
-            if database.starts_with("duckdb://") {
-                backend = Backend::duckdb;
-            } else {
-                // FIXME: Replace this with connectorx when implemented
-                backend = Backend::duckdb;
-            }
+            backend = Backend::duckdb;
         }
     } else {
         database = String::from("");

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,7 @@ type SourcesType = Vec<(String, String)>;
 #[clap(
     name = env!("CARGO_PKG_NAME"),
     version = env!("CARGO_PKG_VERSION"),
-    about = env!("CARGO_PKG_DESCRIPTION"),
-    long_about = format!("pq: query and transform data with PRQL version {} (https://prql-lang.org)", PRQL_VERSION.to_string())
+    about = format!("{} version {} (https://prql-lang.org)", env!("CARGO_PKG_DESCRIPTION"), PRQL_VERSION.to_string())
 )]
 struct Cli {
     /// The file(s) to read data FROM if given

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,7 +207,12 @@ fn main() -> Result<()> {
     if let Some(args_database) = args.database {
         database = args_database;
         if backend == Backend::auto {
-            backend = Backend::duckdb;
+            if database.starts_with("duckdb://") {
+                backend = Backend::duckdb;
+            } else {
+                // FIXME: Replace this with connectorx when implemented
+                backend = Backend::duckdb;
+            }
         }
     } else {
         database = String::from("");


### PR DESCRIPTION
The version of prql-compiler built into this tool may be a bit backward, so informing users of this may help resolve the issue.

I have found that using clap version 4 makes it easy to embed String in help, so I am trying that.
~~So far it is only shown in long_about displayed with `--help` and the display is simple, but I think I can change it to something better if needed.~~

-> Updated to show on about without using long_about for now.

```
$ target/debug/pq -h
pq: query and transform data with PRQL version 0.4.2 (https://prql-lang.org)

Usage: pq [OPTIONS] [QUERY]

Arguments:
  [QUERY]  The PRQL query to be processed if given, otherwise read from stdin [env: PQ_QUERY=] [default: -]

Options:
  -f, --from <FROM>          The file(s) to read data FROM if given [env: PQ_FROM=]
  -t, --to <TO>              The file to write TO if given, otherwise stdout [env: PQ_TO=] [default: -]
  -d, --database <DATABASE>  The database to connect to [env: PQ_DATABASE=]
  -b, --backend <BACKEND>    The backend to use to process the query [env: PQ_BACKEND=] [default: auto] [possible values: auto, datafusion, duckdb]
      --no-exec              Only generate SQL without executing it against files
      --format <FORMAT>      The format to use for the output [env: PQ_FORMAT=] [possible values: csv, json, parquet, table]
  -w, --writer <WRITER>      The Writer to use for writing the output [env: PQ_WRITER=] [default: arrow] [possible values: arrow, backend]
      --sql                  set this to pass a SQL query rather than a PRQL one [env: PQ_SQL=]
  -h, --help                 Print help (see more with '--help')
  -V, --version              Print versio
```